### PR TITLE
Project logo as first readme.md line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![DrawIt! logo](https://user-images.githubusercontent.com/60916242/136795213-67bfb00f-a69d-4346-9612-4586f8a3af78.png "DrawIt!")](https://user-images.githubusercontent.com/60916242/136795213-67bfb00f-a69d-4346-9612-4586f8a3af78.png "DrawIt!")
+[![DrawIt! logo](https://user-images.githubusercontent.com/60916242/136795213-67bfb00f-a69d-4346-9612-4586f8a3af78.png "DrawIt!")](https://yashchaudhari008.github.io/drawit/ "DrawIt!")
 
 A Simple Drawing App made using HTML, CSS, JS and [p5.js](https://p5js.org/).
 


### PR DESCRIPTION
I made a small change to the README.md file which removes the heading "DrawIt!" and replaces it with the logo of the project.

Before:
![Before](https://user-images.githubusercontent.com/60916242/136797816-5b25d1ed-79b9-461d-b260-e5903defa96a.png)

After:
![After](https://user-images.githubusercontent.com/60916242/136797898-51a4e149-3873-40f6-a066-59827bd3d93f.png)