### PR TITLE
Change topbar text to elaborate on if the pen/eraser is currently selected

### DIFF
--- a/AppData/index.js
+++ b/AppData/index.js
@@ -89,9 +89,11 @@ function keyTyped() {
         current_status ^= 1;
 
         if (current_status) {
+			document.getElementById("switch").textContent = "Press Z to toggle to Eraser"
             stroke_colour = pen_colour_picker.value();
         }
         else {
+			document.getElementById("switch").textContent = "Press Z to toggle to Pen"
             stroke_colour = background_colour_picker.value();
         }
     }

--- a/AppData/main.html
+++ b/AppData/main.html
@@ -20,7 +20,7 @@
         <div id='container'>
         
             <div style="display: inline-flex; align-items: center;">
-                <p id='switch'>Press Z to toggle Pen/Eraser</p>
+                <p id='switch'>Press Z to toggle to Eraser</p>
                 <div>
                     <button onclick="clearCanvas();">Clear Canvas</button>
                     <button onclick="saveCanvas('drawit_canvas');">Save Canvas</button>


### PR DESCRIPTION
This PR changes the text on the top left top to better detail what current mode is selected.

## Before
![image](https://user-images.githubusercontent.com/68125679/137559859-c158213d-497e-4350-bebd-a6ea8350046e.png)

## After
![image](https://user-images.githubusercontent.com/68125679/137559934-e5b58af6-e052-47fb-907d-c84c6a3e5a9c.png)
![image](https://user-images.githubusercontent.com/68125679/137559979-79807048-37f0-416c-8567-9b02657ce64c.png)
