### PR TITLE
#48 - Adding a way to allow bg color change without affecting the cur…

### DIFF
--- a/AppData/index.js
+++ b/AppData/index.js
@@ -11,7 +11,7 @@ function setup() {
     canvas.parent('#canvasHolder');
     canvas.elt.onmouseover = () => canvas.isMouseOver = true;
     canvas.elt.onmouseout = () => canvas.isMouseOver = false;
-    background(background_colour);
+    setBackground(background_colour);
 
     createP('Background Colour: ').parent('#controls');
     background_colour_picker = createColorPicker(background_colour);
@@ -81,7 +81,7 @@ function draw() {
     }
 
     if (background_colour_picker.value() != background_colour) {
-        clearCanvas();
+        setBackground(background_colour_picker.value());
     }
 
     if (current_status) {
@@ -121,8 +121,11 @@ function keyTyped() {
 
 function clearCanvas() {
     clear();
-    background_colour = background_colour_picker.value();
-    background(background_colour)
+}
+
+function setBackground(colour) {
+    background_colour = colour;
+    document.querySelector('canvas').style.backgroundColor = colour;
 }
 
 function windowResized() {
@@ -141,4 +144,21 @@ function backToHome() {
         location.href = "../index.html";
     }
     else { }
+}
+
+function saveCanvasInternal(fileName) {
+    document.querySelector('canvas').style.backgroundColor = 'transparent';
+
+    const state = drawingContext.getImageData(0, 0, windowWidth * (sFactor + 0.1), windowHeight * sFactor);
+    const bkp = drawingContext.globalCompositeOperation;
+
+    drawingContext.globalCompositeOperation = 'destination-over';
+    drawingContext.fillStyle = background_colour;
+    drawingContext.fillRect(0, 0, windowWidth * (sFactor + 0.1), windowHeight * sFactor);
+    drawingContext.globalCompositeOperation = bkp;
+
+    saveCanvas(fileName);
+    drawingContext.putImageData(state, 0, 0);
+
+    document.querySelector('canvas').style.backgroundColor = background_colour;
 }

--- a/AppData/index.js
+++ b/AppData/index.js
@@ -149,26 +149,29 @@ function backToHome() {
 
 function saveCanvasInternal(fileName) {
     const canvas = document.querySelector('canvas');
+    
+    const { originalDrawings, originalCompositeOperation } = mergeBgAndDrawings(canvas, width, height);
+    
+    saveCanvas(fileName);
+    
+    separateBgAndDrawings(canvas, originalCompositeOperation, originalDrawings, background_colour);
+}
+
+function mergeBgAndDrawings(canvas) {
     const width = windowWidth * (sFactor + 0.1);
     const height = windowHeight * sFactor;
     const originalDrawings = drawingContext.getImageData(0, 0, width, height);
     const originalCompositeOperation = drawingContext.globalCompositeOperation;
-    
-    mergeBgAndDrawings(canvas, width, height);
-    
-    saveCanvas(fileName);
-    
-    separateBgAndDrawings(canvas, width, height, originalCompositeOperation, originalDrawings, background_colour);
-}
 
-function mergeBgAndDrawings(canvas, width, height) {
     canvas.style.backgroundColor = 'transparent';
     drawingContext.globalCompositeOperation = 'destination-over';
     drawingContext.fillStyle = background_colour;
     drawingContext.fillRect(0, 0, width, height);
+
+    return { originalDrawings, originalCompositeOperation };
 }
 
-function separateBgAndDrawings(canvas, width, height, originalCompositeOperation, originalDrawings, bgColor) {
+function separateBgAndDrawings(canvas, originalCompositeOperation, originalDrawings, bgColor) {
     drawingContext.globalCompositeOperation = originalCompositeOperation;
     drawingContext.putImageData(originalDrawings, 0, 0);
     canvas.style.backgroundColor = bgColor;

--- a/AppData/index.js
+++ b/AppData/index.js
@@ -148,18 +148,28 @@ function backToHome() {
 }
 
 function saveCanvasInternal(fileName) {
-    document.querySelector('canvas').style.backgroundColor = 'transparent';
+    const canvas = document.querySelector('canvas');
+    const width = windowWidth * (sFactor + 0.1);
+    const height = windowHeight * sFactor;
+    const originalDrawings = drawingContext.getImageData(0, 0, width, height);
+    const originalCompositeOperation = drawingContext.globalCompositeOperation;
+    
+    mergeBgAndDrawings(canvas, width, height);
+    
+    saveCanvas(fileName);
+    
+    separateBgAndDrawings(canvas, width, height, originalCompositeOperation, originalDrawings, background_colour);
+}
 
-    const state = drawingContext.getImageData(0, 0, windowWidth * (sFactor + 0.1), windowHeight * sFactor);
-    const bkp = drawingContext.globalCompositeOperation;
-
+function mergeBgAndDrawings(canvas, width, height) {
+    canvas.style.backgroundColor = 'transparent';
     drawingContext.globalCompositeOperation = 'destination-over';
     drawingContext.fillStyle = background_colour;
-    drawingContext.fillRect(0, 0, windowWidth * (sFactor + 0.1), windowHeight * sFactor);
-    drawingContext.globalCompositeOperation = bkp;
+    drawingContext.fillRect(0, 0, width, height);
+}
 
-    saveCanvas(fileName);
-    drawingContext.putImageData(state, 0, 0);
-
-    document.querySelector('canvas').style.backgroundColor = background_colour;
+function separateBgAndDrawings(canvas, width, height, originalCompositeOperation, originalDrawings, bgColor) {
+    drawingContext.globalCompositeOperation = originalCompositeOperation;
+    drawingContext.putImageData(originalDrawings, 0, 0);
+    canvas.style.backgroundColor = bgColor;
 }

--- a/AppData/index.js
+++ b/AppData/index.js
@@ -102,21 +102,22 @@ function draw() {
 }
 
 function keyTyped() {
-    let pressed_key = key.toUpperCase();
+    const pressed_key = key.toUpperCase();
 
-    if (pressed_key == 'Z') {
-        //switch between pen and eraser
-        current_status ^= 1;
+    if (pressed_key != 'Z')
+        return;
 
-        if (current_status) {
-			document.getElementById("switch").textContent = "Press Z to toggle to Eraser"
-            stroke_colour = pen_colour_picker.value();
-        }
-        else {
-			document.getElementById("switch").textContent = "Press Z to toggle to Pen"
-            stroke_colour = background_colour_picker.value();
-        }
+    //switch between pen and eraser
+    current_status ^= 1;
+
+    if (current_status) {
+        document.getElementById("switch").textContent = "Press Z to toggle to Eraser"
+        noErase();
+        return;
     }
+    
+    document.getElementById("switch").textContent = "Press Z to toggle to Pen"
+    erase();
 }
 
 function clearCanvas() {

--- a/AppData/main.html
+++ b/AppData/main.html
@@ -23,7 +23,7 @@
                 <p id='switch'>Press Z to toggle to Eraser</p>
                 <div>
                     <button onclick="clearCanvas();">Clear Canvas</button>
-                    <button onclick="saveCanvas('drawit_canvas');">Save Canvas</button>
+                    <button onclick="saveCanvasInternal('drawit_canvas');">Save Canvas</button>
                     <button onclick="backToHome()">Back to Home</button>
                 </div>
                 <div class='Div' id='controls'> </div>


### PR DESCRIPTION
After some investigation, I noticed the background actually is applied as a fill operation, which wouldn't allow us to replace it easily. So, I left canvas as transparent and changed the action to only affect the canva HTML element background color. Then, on save, store the current state, then blends the background and the content to save and restore the state to continue working.
:)